### PR TITLE
fix: preserve parametric sensitivity plot legends

### DIFF
--- a/src/sdom/analytic_tools/_parametric.py
+++ b/src/sdom/analytic_tools/_parametric.py
@@ -360,7 +360,19 @@ def _save_parametric_figure(
     *,
     extra_artists: list[Artist] | None = None,
 ) -> None:
-    """Save a parametric figure while preserving legends outside the axes."""
+    """Save a parametric figure with outside legend artists preserved.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure to lay out, save, and close.
+    output_path : str
+        Destination path for the rendered figure. Parent directories are
+        created automatically when missing.
+    extra_artists : list of matplotlib.artist.Artist, optional
+        Additional artists, such as legends anchored outside the axes, to
+        include when computing the tight saved bounding box.
+    """
     ensure_dir(os.path.dirname(os.path.abspath(output_path)))
     fig.tight_layout(rect=[0.0, 0.0, 0.82, 1.0])
     fig.savefig(

--- a/src/sdom/analytic_tools/_parametric.py
+++ b/src/sdom/analytic_tools/_parametric.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+from matplotlib.artist import Artist
 import numpy as np
 import pandas as pd
 
@@ -25,7 +26,7 @@ from ._colors import (
     infer_storage_technologies,
 )
 from ._single import plot_results
-from ._utils import ensure_dir, save_figure
+from ._utils import ensure_dir
 
 if TYPE_CHECKING:
     from ..parametric.study import ParametricStudy
@@ -349,6 +350,29 @@ def plot_parametric_results(
 
 
 # ---------------------------------------------------------------------------
+# Internal: save helpers
+# ---------------------------------------------------------------------------
+
+
+def _save_parametric_figure(
+    fig: plt.Figure,
+    output_path: str,
+    *,
+    extra_artists: list[Artist] | None = None,
+) -> None:
+    """Save a parametric figure while preserving legends outside the axes."""
+    ensure_dir(os.path.dirname(os.path.abspath(output_path)))
+    fig.tight_layout(rect=[0.0, 0.0, 0.82, 1.0])
+    fig.savefig(
+        output_path,
+        dpi=_DPI,
+        bbox_inches="tight",
+        bbox_extra_artists=extra_artists or None,
+    )
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
 # Internal: metadata helpers
 # ---------------------------------------------------------------------------
 
@@ -569,6 +593,8 @@ def _plot_grouped_stacked_bars(
     ax.set_xticks(group_positions)
     ax.set_xticklabels(groups, fontsize=11)
 
+    legend_artists: list[Artist] = []
+
     # Technology legend
     tech_handles = [
         mpatches.Patch(facecolor=color_map.get(t, "#CCCCCC"), label=t)
@@ -584,6 +610,7 @@ def _plot_grouped_stacked_bars(
         title="Technology",
     )
     ax.add_artist(tech_legend)
+    legend_artists.append(tech_legend)
 
     # Hue legend (only when multiple hues)
     if n_hues > 1:
@@ -591,7 +618,7 @@ def _plot_grouped_stacked_bars(
             mpatches.Patch(facecolor="gray", alpha=0.4 + 0.5 * i / max(n_hues - 1, 1), label=h)
             for i, h in enumerate(hues)
         ]
-        ax.legend(
+        hue_legend = ax.legend(
             handles=hue_handles,
             loc="upper left",
             bbox_to_anchor=(1.02, 0.5),
@@ -599,6 +626,7 @@ def _plot_grouped_stacked_bars(
             fontsize=10,
             title="Scenarios",
         )
+        legend_artists.append(hue_legend)
 
     ax.set_xlabel("Case group", fontsize=13, fontweight="bold")
     ax.set_ylabel(ylabel, fontsize=13, fontweight="bold")
@@ -606,8 +634,7 @@ def _plot_grouped_stacked_bars(
     ax.yaxis.grid(True, linestyle="--", alpha=0.3)
     ax.set_axisbelow(True)
 
-    plt.tight_layout()
-    save_figure(fig, output_path, dpi=_DPI)
+    _save_parametric_figure(fig, output_path, extra_artists=legend_artists)
 
 
 # ---------------------------------------------------------------------------
@@ -688,14 +715,16 @@ def _plot_curtailment_bars(
     ax.set_xticks(group_positions)
     ax.set_xticklabels(groups, fontsize=11)
 
+    legend_artists: list[Artist] = []
     if n_hues > 1:
-        ax.legend(
+        hue_legend = ax.legend(
             loc="upper left",
             bbox_to_anchor=(1.02, 1.0),
             frameon=False,
             fontsize=10,
             title="Scenarios",
         )
+        legend_artists.append(hue_legend)
 
     ax.set_xlabel("Case group", fontsize=13, fontweight="bold")
     ax.set_ylabel(ylabel, fontsize=13, fontweight="bold")
@@ -703,8 +732,7 @@ def _plot_curtailment_bars(
     ax.yaxis.grid(True, linestyle="--", alpha=0.3)
     ax.set_axisbelow(True)
 
-    plt.tight_layout()
-    save_figure(fig, output_path, dpi=_DPI)
+    _save_parametric_figure(fig, output_path, extra_artists=legend_artists)
 
 
 # ---------------------------------------------------------------------------
@@ -816,6 +844,8 @@ def _plot_cost_comparison_bars(
     ax.set_xticks(group_positions)
     ax.set_xticklabels(groups, fontsize=11)
 
+    legend_artists: list[Artist] = []
+
     # Technology legend
     tech_handles = [
         mpatches.Patch(facecolor=color_map.get(t, "#CCCCCC"), label=t)
@@ -831,6 +861,7 @@ def _plot_cost_comparison_bars(
         title="Technology",
     )
     ax.add_artist(tech_legend)
+    legend_artists.append(tech_legend)
 
     # Cost-type legend (CAPEX solid vs OPEX hatched)
     cost_type_handles = [
@@ -846,6 +877,7 @@ def _plot_cost_comparison_bars(
         title="Cost type",
     )
     ax.add_artist(cost_legend)
+    legend_artists.append(cost_legend)
 
     # Hue legend (only when multiple hues)
     if n_hues > 1:
@@ -853,7 +885,7 @@ def _plot_cost_comparison_bars(
             mpatches.Patch(facecolor="gray", alpha=0.4 + 0.5 * i / max(n_hues - 1, 1), label=h)
             for i, h in enumerate(hues)
         ]
-        ax.legend(
+        hue_legend = ax.legend(
             handles=hue_handles,
             loc="upper left",
             bbox_to_anchor=(1.02, 0.25),
@@ -861,6 +893,7 @@ def _plot_cost_comparison_bars(
             fontsize=10,
             title="Scenarios",
         )
+        legend_artists.append(hue_legend)
 
     ax.set_xlabel("Case group", fontsize=13, fontweight="bold")
     ax.set_ylabel(ylabel, fontsize=13, fontweight="bold")
@@ -868,5 +901,4 @@ def _plot_cost_comparison_bars(
     ax.yaxis.grid(True, linestyle="--", alpha=0.3)
     ax.set_axisbelow(True)
 
-    plt.tight_layout()
-    save_figure(fig, output_path, dpi=_DPI)
+    _save_parametric_figure(fig, output_path, extra_artists=legend_artists)

--- a/tests/test_analytic_tools.py
+++ b/tests/test_analytic_tools.py
@@ -190,7 +190,161 @@ class TestSinglePlots:
 # ---------------------------------------------------------------------------
 # _parametric.py tests
 # ---------------------------------------------------------------------------
-from sdom.analytic_tools._parametric import _available_dims, _split_into_chunks
+from sdom.analytic_tools._parametric import (
+    _available_dims,
+    _plot_cost_comparison_bars,
+    _plot_grouped_stacked_bars,
+    _save_parametric_figure,
+    _split_into_chunks,
+)
+
+
+def _make_parametric_tech_df(hues=None) -> pd.DataFrame:
+    """Create small long-form technology data for parametric plot tests."""
+    hues = hues or ["_all_"]
+    rows = []
+    values = {
+        "Thermal": 1200.0,
+        "Solar PV": 2400.0,
+        "Wind": 1800.0,
+        "PHS": 300.0,
+        "H2": 100.0,
+    }
+    for group_idx, group in enumerate(["GenMix_Target=0.0", "GenMix_Target=1.0"]):
+        for hue_idx, hue in enumerate(hues):
+            for tech, value in values.items():
+                rows.append(
+                    {
+                        "group_label": group,
+                        "hue_label": hue,
+                        "technology": tech,
+                        "capacity_mw": value + 100 * group_idx + 10 * hue_idx,
+                        "generation_mwh": (value + 100 * group_idx + 10 * hue_idx) * 1000,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _make_parametric_cost_df(hues=None) -> pd.DataFrame:
+    """Create small long-form cost data for parametric plot tests."""
+    hues = hues or ["_all_"]
+    rows = []
+    values = {
+        "Thermal": (1_200_000.0, 120_000.0),
+        "Solar PV": (2_400_000.0, 24_000.0),
+        "Wind": (1_800_000.0, 36_000.0),
+        "PHS": (300_000.0, 12_000.0),
+        "H2": (100_000.0, 8_000.0),
+    }
+    for group_idx, group in enumerate(["GenMix_Target=0.0", "GenMix_Target=1.0"]):
+        for hue_idx, hue in enumerate(hues):
+            for tech, (capex, opex) in values.items():
+                rows.append(
+                    {
+                        "group_label": group,
+                        "hue_label": hue,
+                        "technology": tech,
+                        "capex_usd": capex + 1000 * group_idx + 100 * hue_idx,
+                        "opex_usd": opex + 100 * group_idx + 10 * hue_idx,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+class TestParametricLegends:
+    def test_save_parametric_figure_writes_png_with_extra_artists(self, tmp_path):
+        """The parametric save helper should write figures with outside legends."""
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1], label="Thermal")
+        legend = ax.legend(loc="upper left", bbox_to_anchor=(1.02, 1.0), title="Technology")
+        ax.add_artist(legend)
+        output_path = tmp_path / "capacity_comparison.png"
+
+        _save_parametric_figure(fig, str(output_path), extra_artists=[legend])
+
+        assert output_path.is_file()
+        assert output_path.stat().st_size > 0
+
+    def test_grouped_stacked_bars_exports_technology_legend(self, tmp_path, monkeypatch):
+        """Capacity/generation plots should save outside technology legends."""
+        captured = {}
+
+        def fake_save(fig, output_path, *, extra_artists=None):
+            captured["output_path"] = output_path
+            captured["legend_titles"] = [artist.get_title().get_text() for artist in extra_artists]
+
+        monkeypatch.setattr("sdom.analytic_tools._parametric._save_parametric_figure", fake_save)
+        tech_order = ["Thermal", "Solar PV", "Wind", "PHS", "H2"]
+        color_map = {tech: f"C{i}" for i, tech in enumerate(tech_order)}
+
+        _plot_grouped_stacked_bars(
+            tech_df=_make_parametric_tech_df(),
+            value_col="capacity_mw",
+            groups=["GenMix_Target=0.0", "GenMix_Target=1.0"],
+            hues=["_all_"],
+            tech_order=tech_order,
+            color_map=color_map,
+            title="Installed Capacity by Technology — Sensitivity Analysis",
+            ylabel="Capacity (GW)",
+            unit_divisor=1000.0,
+            output_path=str(tmp_path / "capacity_comparison.png"),
+        )
+
+        assert captured["output_path"].endswith("capacity_comparison.png")
+        assert captured["legend_titles"] == ["Technology"]
+
+    def test_grouped_stacked_bars_exports_technology_and_hue_legends(self, tmp_path, monkeypatch):
+        """Scenario/hue legends should remain visible with technology legends."""
+        captured = {}
+
+        def fake_save(fig, output_path, *, extra_artists=None):
+            captured["legend_titles"] = [artist.get_title().get_text() for artist in extra_artists]
+
+        monkeypatch.setattr("sdom.analytic_tools._parametric._save_parametric_figure", fake_save)
+        tech_order = ["Thermal", "Solar PV", "Wind", "PHS", "H2"]
+        color_map = {tech: f"C{i}" for i, tech in enumerate(tech_order)}
+
+        _plot_grouped_stacked_bars(
+            tech_df=_make_parametric_tech_df(hues=["scenario_a", "scenario_b"]),
+            value_col="generation_mwh",
+            groups=["GenMix_Target=0.0", "GenMix_Target=1.0"],
+            hues=["scenario_a", "scenario_b"],
+            tech_order=tech_order,
+            color_map=color_map,
+            title="Annual Generation by Technology — Sensitivity Analysis",
+            ylabel="Generation (TWh)",
+            unit_divisor=1e6,
+            output_path=str(tmp_path / "generation_comparison.png"),
+        )
+
+        assert captured["legend_titles"] == ["Technology", "Scenarios"]
+
+    def test_cost_comparison_exports_all_outside_legends(self, tmp_path, monkeypatch):
+        """Cost plots should save technology, cost-type, and scenario legends."""
+        captured = {}
+
+        def fake_save(fig, output_path, *, extra_artists=None):
+            captured["legend_titles"] = [artist.get_title().get_text() for artist in extra_artists]
+
+        monkeypatch.setattr("sdom.analytic_tools._parametric._save_parametric_figure", fake_save)
+        tech_order = ["Thermal", "Solar PV", "Wind", "PHS", "H2"]
+        color_map = {tech: f"C{i}" for i, tech in enumerate(tech_order)}
+
+        _plot_cost_comparison_bars(
+            cost_df=_make_parametric_cost_df(hues=["scenario_a", "scenario_b"]),
+            groups=["GenMix_Target=0.0", "GenMix_Target=1.0"],
+            hues=["scenario_a", "scenario_b"],
+            tech_order=tech_order,
+            color_map=color_map,
+            title="CAPEX and OPEX by Technology — Sensitivity Analysis",
+            ylabel="Cost ($M USD)",
+            unit_divisor=1e6,
+            output_path=str(tmp_path / "cost_comparison.png"),
+        )
+
+        assert captured["legend_titles"] == ["Technology", "Cost type", "Scenarios"]
 
 
 class TestParametricHelpers:


### PR DESCRIPTION
## Summary

Closes #53.

This PR fixes parametric sensitivity plots whose technology/scenario legends are positioned outside the axes but were not reliably preserved in saved PNG output. It also includes a readability tuning pass for the same parametric sensitivity plots and centralizes plot styling/layout parameters as private constants.

Changes implemented:

- Added a private `_save_parametric_figure(...)` helper for parametric plots.
  - Reserves right-side layout space with `_LAYOUT_RECT`.
  - Saves with `bbox_inches="tight"` and forwards explicit `bbox_extra_artists` for outside legends.
  - Closes figures after save to preserve existing memory-management behavior.
  - Includes a NumPy-style docstring describing parameters.
- Updated `_plot_grouped_stacked_bars(...)` so capacity and generation comparison plots collect and save:
  - `Technology` legend
  - `Scenarios` legend when multiple hues are present
- Updated `_plot_curtailment_bars(...)` to use the same parametric save helper and preserve scenario legends when present.
- Updated `_plot_cost_comparison_bars(...)` so cost comparison plots collect and save:
  - `Technology` legend
  - `Cost type` legend
  - `Scenarios` legend when multiple hues are present
- Added private constants for parametric sensitivity plot defaults and styling, including:
  - max cases per figure (`_MAX_CASES_PER_FIGURE`)
  - layout rectangle and legend anchor positions
  - bar cluster width, edge color, linewidth, hatch pattern, grid style, and alpha values
  - title padding and font sizes
- Applied readability font sizing while leaving figure titles and axis titles unchanged in the latest tuning passes:
  - x-tick labels: `12 -> 13`
  - y-tick labels: default -> `12`
  - legend text: `11 -> 12`
  - bar value labels: `9 -> 10`
  - axis labels remain `14`
  - plot titles remain `17`
- Added regression coverage in `tests/test_analytic_tools.py` for:
  - Saving a parametric figure with outside legend artists
  - Capacity/generation stacked-bar technology legend export
  - Capacity/generation stacked-bar technology + hue legend export
  - Cost comparison technology + cost-type + hue legend export
- Addressed Copilot review comments by closing Matplotlib figures in monkeypatched fake savers.

## Public API compatibility

No public API changes. Existing callers continue to use:

```python
plot_parametric_results(
    study,
    results,
    group_by="GenMix_Target",
    output_dir=str(output_dir),
)
```

The change is limited to internal parametric plotting save/layout behavior, internal plot constants, and test coverage.

## Layout risk

The font-size updates are intentionally small and scoped only to the parametric sensitivity plotting helpers touched by this PR. The legend-preservation fix already reserves right-side layout space and includes outside legend artists during save, which helps reduce clipping risk for exported PNGs.

## Validation

Targeted validation after the legend/docstring changes:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 10.03s
```

Targeted validation after the initial font-size update:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 10.14s
```

Targeted validation after centralizing plot constants:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 9.48s
```

Targeted validation after addressing Copilot review comments:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 14.09s
```

Targeted validation after increasing secondary plot text sizes:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 13.21s
```

Targeted validation after increasing y-axis tick labels:

```powershell
.venv\Scripts\python.exe -m pytest tests/test_analytic_tools.py -q
```

Result:

```text
31 passed in 11.42s
```

Full test suite after the core legend fix:

```powershell
.venv\Scripts\python.exe -m pytest
```

Result:

```text
437 passed, 2 skipped, 3 warnings in 352.46s (0:05:52)
```

Additional repository checks:

```powershell
git diff --check -- src/sdom/analytic_tools/_parametric.py
```

Result: passed with no whitespace errors.

Commit signature verification:

```text
aaf306c G fix(plots): preserve parametric legends
399bcdc G docs(plots): document parametric save helper
9441794 G style(plots): increase parametric plot font sizes
bbadb31 G refactor(plots): centralize parametric plot constants
f5190e0 G test(plots): close monkeypatched figures
d84113b G style(plots): enlarge secondary plot text
2f94242 G style(plots): enlarge y-axis tick labels
```

## Notes

A targeted Ruff check for the touched files was attempted earlier, but the existing file-level style currently reports numerous pre-existing issues in these files (for example legacy `typing.List`/`Dict` annotations, import-placement style in the test module, and docstring/comment wording). I kept this PR surgical and did not perform unrelated lint modernization.
